### PR TITLE
Fix build failure on kernel 7.0+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -872,8 +872,11 @@ EXTRA_CFLAGS += -I$(src)/platform
 OBJS += $(_PLATFORM_FILES)
 
 KER_MAJOR_6 := $(shell echo `MAKEFLAGS= $(MAKE) -s -C $(KSRC) kernelversion 2>/dev/null | cut -d. -f1` \>= 6 | bc -l)
+KER_MAJOR_7 := $(shell echo `MAKEFLAGS= $(MAKE) -s -C $(KSRC) kernelversion 2>/dev/null | cut -d. -f1` \>= 7 | bc -l)
 KER_MINOR_13 := $(shell echo `MAKEFLAGS= $(MAKE) -s -C $(KSRC) kernelversion 2>/dev/null | cut -d. -f2` \>= 13 | bc -l)
-ifeq ($(KER_MAJOR_6), 1)
+ifeq ($(KER_MAJOR_7), 1)
+export KBUILD_ABS_SRCTREE := 1
+else ifeq ($(KER_MAJOR_6), 1)
 ifeq ($(KER_MINOR_13), 1)
 export KBUILD_ABS_SRCTREE := 1
 endif
@@ -920,7 +923,9 @@ endif
 include $(src)/phl/phl.mk
 
 KER_MINOR_15 := $(shell cd $(KSRC); echo `make kernelversion | cut -d. -f2` \>= 15 | bc -l)
-ifeq ($(KER_MAJOR_6), 1)
+ifeq ($(KER_MAJOR_7), 1)
+ccflags-y := $(EXTRA_CFLAGS)
+else ifeq ($(KER_MAJOR_6), 1)
 ifeq ($(KER_MINOR_15), 1)
 ccflags-y := $(EXTRA_CFLAGS)
 endif


### PR DESCRIPTION
The version checks for `KBUILD_ABS_SRCTREE` (6.13+) and the `EXTRA_CFLAGS` to `ccflags-y` migration (6.15+) both check for `major >= 6 AND minor >= threshold`. On kernel 7.0, the major passes but minor 0 fails the threshold check, so the include paths never get set and every file fails with `drv_types.h: No such file or directory`.

Adds `KER_MAJOR_7` to bypass the minor check on 7.x kernels.

**Tested clean builds on:**
- 6.17.1 (Fedora 43)
- 6.19.10 (Fedora 43)
- 7.0.0-rc6 (Fedora koji headers)