### PR TITLE
Fix kernel panic in monitor mode on frames addressed to other stations

### DIFF
--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -5787,6 +5787,11 @@ exit:
 
 	pmlmepriv = &(prframe->u.hdr.adapter)->mlmepriv;
 	if (check_fwstate(pmlmepriv, WIFI_MONITOR_STATE)) {
+		/* A frame not addressed to a local interface never had a link
+		 * assigned above, and the monitor path dereferences it.
+		 */
+		if (!prframe->u.hdr.adapter_link)
+			prframe->u.hdr.adapter_link = GET_PRIMARY_LINK(prframe->u.hdr.adapter);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
 			recv_frame_monitor(prframe->u.hdr.adapter, prframe, rx_req);
 #endif


### PR DESCRIPTION
@morrownr Monitor mode panics the machine as soon as a unicast frame meant for another station arrives.

`adapter_link` is left NULL for a unicast frame that is not addressed to a local interface, and in monitor mode most frames are exactly that. The monitor path then reaches `rtw_get_oper_chdef()` with that NULL and derefs it building the radiotap header. Broadcast frames do get a link, which is why beacons alone never showed it.

It is taken in the RX tasklet, so it comes out as `Kernel panic - not syncing: Fatal exception in interrupt` rather than an oops the machine walks away from.

Not reachable in a default build, which has `CONFIG_WIFI_MONITOR = n`.

Tested both ways on 6.12.101 with monitor mode enabled, on a BrosTrend AX1L. Stock panics within a quarter of a second of entering monitor mode. Patched holds monitor mode for fifty seconds and captures normally, with the radiotap channel correct.

Same fix in rtl8852cu, tested there on an AX8L.
